### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-base-image.yml
+++ b/.github/workflows/publish-base-image.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: bensmithdeveloper/githubchart
           username: bensmithdeveloper


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore